### PR TITLE
shorter alternative to inline for loop

### DIFF
--- a/src/Cpu/Op.zig
+++ b/src/Cpu/Op.zig
@@ -522,15 +522,8 @@ fn printHexes(outStream: var, length: u3, val: u16) !void {
 // -- init helpers
 
 fn init(comptime id: Id, arg0: Arg, arg1: Arg) Op {
-    const ResultMeta: type = blk: {
-        inline for (std.meta.fields(Id)) |field| {
-            if (field.value == @enumToInt(id)) {
-                const func = @field(Op.impl, field.name);
-                break :blk @typeInfo(@TypeOf(func)).Fn.return_type.?;
-            }
-        }
-        unreachable;
-    };
+    const func = @field(Op.impl, @tagName(id));
+    const ResultMeta = @typeInfo(@TypeOf(func)).Fn.return_type.?;
 
     return .{
         .id = id,


### PR DESCRIPTION
I was messing around trying to figure out ways to shrink the size of the .wasm.  While that didn't materialize, i stumbled across this small source code simplification. 

This works because op is a comptime parameter.  I was hoping to use the same technique in Cpu.op_step but it's op isn't comptime known.  